### PR TITLE
Add etcd ssl certs on bastion node, fixes #112

### DIFF
--- a/modules.tf
+++ b/modules.tf
@@ -86,6 +86,7 @@ module "bastion" {
   internal-tld = "${ var.internal-tld }"
   key-name = "${ var.aws["key-name"] }"
   name = "${ var.name }"
+  region = "${ var.aws["region"] }"
   security-group-id = "${ module.security.bastion-id }"
   subnet-ids = "${ module.vpc.subnet-ids-public }"
   vpc-id = "${ module.vpc.id }"

--- a/modules/bastion/ec2.tf
+++ b/modules/bastion/ec2.tf
@@ -25,14 +25,6 @@ resource "aws_instance" "bastion" {
   ]
 }
 
-data "template_file" "user-data" {
-  template = "${ file( "${ path.module }/user-data.yml" )}"
-
-  vars {
-    internal-tld = "${ var.internal-tld }"
-  }
-}
-
 resource "null_resource" "dummy_dependency" {
   depends_on = [ "aws_instance.bastion" ]
 }

--- a/modules/bastion/iam.tf
+++ b/modules/bastion/iam.tf
@@ -34,7 +34,7 @@ resource "aws_iam_role_policy" "bastion" {
         "s3:List*",
         "s3:Get*"
       ],
-      "Resource": [ "arn:aws:s3:::${ var.bucket-prefix }-ssl/*" ]
+      "Resource": [ "arn:aws:s3:::${ var.bucket-prefix }/*" ]
     }
   ]
 }

--- a/modules/bastion/io.tf
+++ b/modules/bastion/io.tf
@@ -1,4 +1,5 @@
 variable "ami-id" {}
+variable "region" {}
 variable "bucket-prefix" {}
 variable "cidr-allow-ssh" {}
 variable "depends-id" {}

--- a/modules/bastion/user-data.tf
+++ b/modules/bastion/user-data.tf
@@ -1,0 +1,10 @@
+data "template_file" "user-data" {
+  template = "${ file( "${ path.module }/user-data.yml" )}"
+
+  vars {
+    internal-tld = "${ var.internal-tld }"
+    bucket = "${ var.bucket-prefix }"
+    region = "${ var.region }"
+    ssl-tar = "/ssl/k8s-etcd.tar"
+  }
+}

--- a/modules/bastion/user-data.yml
+++ b/modules/bastion/user-data.yml
@@ -7,20 +7,48 @@ coreos:
 
   etcd2:
     discovery-srv: ${ internal-tld }
+    peer-trusted-ca-file: /etc/kubernetes/ssl/ca.pem
+    peer-client-cert-auth: true
+    peer-cert-file: /etc/kubernetes/ssl/k8s-etcd.pem
+    peer-key-file: /etc/kubernetes/ssl/k8s-etcd-key.pem
     proxy: on
 
   units:
     - name: etcd2.service
       command: start
-    - name: s3-iam-get.service
+      drop-ins:
+        - name: wait-for-certs.conf
+          content: |
+            [Unit]
+            After=get-ssl.service
+            Requires=get-ssl.service
+
+    - name: s3-get-presigned-url.service
       command: start
       content: |
         [Unit]
-        Description=s3-iam-get
+        After=network-online.target
+        Description=Install s3-get-presigned-url
+        Requires=network-online.target
         [Service]
-        Type=oneshot
-        RemainAfterExit=yes
         ExecStartPre=-/usr/bin/mkdir -p /opt/bin
-        ExecStartPre=/usr/bin/curl -L -o /opt/bin/s3-iam-get \
-          https://raw.githubusercontent.com/kz8s/s3-iam-get/master/s3-iam-get
-        ExecStart=/usr/bin/chmod +x /opt/bin/s3-iam-get
+        ExecStart=/usr/bin/curl -fL -o /opt/bin/s3-get-presigned-url \
+          https://github.com/kz8s/s3-get-presigned-url/releases/download/v0.1/s3-get-presigned-url_linux_amd64
+        ExecStart=/usr/bin/chmod +x /opt/bin/s3-get-presigned-url
+        RemainAfterExit=yes
+        Type=oneshot
+
+    - name: get-ssl.service
+      command: start
+      content: |
+        [Unit]
+        After=s3-get-presigned-url.service
+        Description=Get ssl artifacts from s3 bucket using IAM role
+        Requires=s3-get-presigned-url.service
+        [Service]
+        ExecStartPre=-/usr/bin/mkdir -p /etc/kubernetes/ssl
+        ExecStart=/bin/sh -c "/usr/bin/curl -f $(/opt/bin/s3-get-presigned-url \
+          ${ region } ${ bucket } ${ ssl-tar }) | tar xv -C /etc/kubernetes/ssl/"
+        RemainAfterExit=yes
+        Type=oneshot
+


### PR DESCRIPTION
* Adjust the policy for the bastion instance profile.
* Use the newer s3-signed-url utility to fetch tarball with certs.
* Adjust cloud-init data to download/extract certs.
* Adjust etcd2.service config to wait on cert download.